### PR TITLE
Support unlimited number of worktrees

### DIFF
--- a/select-airflow-worktree.sh
+++ b/select-airflow-worktree.sh
@@ -28,7 +28,7 @@ select-airflow-worktree() {
     # $GIT_DIR is not the root directory of a bare repository.
     # Next command extracts it on both "normal" and bare repositories.
     # DOES NOT SUPPORT SPACES IN NAME OF BRANCHES/WORKTREES/DIRECTORIES.
-    git_dir=$(git worktree list | head -n 1 | cut -d" " -f1)
+    git_dir=$(head -n 1 < <(git worktree list) | cut -d" " -f1)
 
     # Returns true or false
     is_bare_repo=$(git config --get core.bare)

--- a/select-airflow-worktree.sh
+++ b/select-airflow-worktree.sh
@@ -28,7 +28,7 @@ select-airflow-worktree() {
     # $GIT_DIR is not the root directory of a bare repository.
     # Next command extracts it on both "normal" and bare repositories.
     # DOES NOT SUPPORT SPACES IN NAME OF BRANCHES/WORKTREES/DIRECTORIES.
-    git_dir=$(git worktree list | head -1 | cut -d" " -f1)
+    git_dir=$(git worktree list | head -n 1 | cut -d" " -f1)
 
     # Returns true or false
     is_bare_repo=$(git config --get core.bare)

--- a/select-airflow-worktree.sh
+++ b/select-airflow-worktree.sh
@@ -38,7 +38,7 @@ select-airflow-worktree() {
         if [ "${is_bare_repo}" == false ]; then
             info "Not a bare repo, skipping airflow-worktree"
         else
-            # Informationn of the worktree we are in
+            # Information of the worktree we are in
             worktree_info=$(git worktree list | grep "$PWD " | xargs)
 
             # DOES NOT SUPPORT SPACES IN NAME OF BRANCHES/WORKTREES/DIRECTORIES.


### PR DESCRIPTION
fixes #3 

Pipe `git worktree list | head -n 1` was failing when the output of `git worktree list` became so large that printing its output to `stdout` took longer than `head -n 1` to complete; hence the hook stopped earlier with no warnings or errors (`set` is using `errexit` on `pipefail`).

ELI5 explanation:

```sh
first_command | second_command
```
When `second_command` exits before `first_command` stops writing to `stdout` the pipe fails.

I modified the extraction of `git_dir` to use [process substitution](https://tldp.org/LDP/abs/html/process-sub.html) to redirect the output of `git worktree list` to `head` instead of pipeing it, thus avoiding `errexit` on `pipefail` to terminate the script in this scenario.

This is not needed for other pipes in the script, those should be guaranteed to have small `stdout`s to  pipe or the 2nd command reads the entire `stdin` block and doesn't exit earlier (this is the case for plain `grep`).
