### PR TITLE
Switch to `find` for exact directory matching in `.airflowignore`

### DIFF
--- a/select-airflow-worktree.sh
+++ b/select-airflow-worktree.sh
@@ -47,8 +47,12 @@ select-airflow-worktree() {
             # Path to the workspace relative to the repository's root directory
             worktree_rel_path="${worktree_abs_path##"${git_dir}"/}"
 
-            # Ignore everything but the worktree directory
-            /usr/bin/env ls --file-type -AI "${worktree_rel_path}" "${git_dir}" > "${git_dir}/.airflowignore"
+            # Ignore all directories except root and worktree
+            /usr/bin/env find "${git_dir}" -maxdepth 1 -type d \
+                -not -path "${git_dir}" \
+                -not -path "${worktree_abs_path}" \
+                -printf '^%P/\n' | sort \
+                > "${git_dir}/.airflowignore"
 
             info ".airflowignore updated to load DAGs from ${worktree_rel_path}"
         fi


### PR DESCRIPTION
## Description

This resolves a bug where directories were incorrectly ignored if their names were substrings of other directory names (fixes #5).

## Changes

I refactored the code that populates the `.airflowignore` file, replacing the `ls` command with the `find` command. This allows for exact matching of directory names and excludes file names from the search.

The Airflow UI will correctly list the DAGs from the checked-out branch.

