### PR TITLE
Support Nested Worktrees and use Git's built-in commands

### DIFF
--- a/select-airflow-worktree.sh
+++ b/select-airflow-worktree.sh
@@ -39,11 +39,11 @@ select-airflow-worktree() {
                         (
                 git worktree list |
                     awk '{print $1}' |                   # Use the first column (worktree paths)
-                    grep -vE "^${git_dir}$" |            # Exclude the git's root dir
+                    grep -vE "^${git_root_dir}$" |            # Exclude the git's root dir
                     grep -vE "^${worktree_abs_path}$" |  # Exclude the current worktree
-                    sed "s|${git_dir}/||g" |             # Convert worktrees to paths relative to the git's root dir
-                    sed 's/.*/^&$/'                      # Append ^ at start and $ at end to ignore exact matches
-            ) > "${git_dir}/.airflowignore"
+                    sed "s|${git_root_dir}/||g" |             # Convert worktrees to paths relative to the git's root dir
+                    sed 's/.*/^&\//'                     # Append ^ at start and / at end to ignore directory matches
+            ) > "${git_root_dir}/.airflowignore"
 
             info ".airflowignore updated to load DAGs from ${worktree_rel_path}"
         fi

--- a/select-airflow-worktree.sh
+++ b/select-airflow-worktree.sh
@@ -33,14 +33,7 @@ select-airflow-worktree() {
             info "Not a bare repo, skipping airflow-worktree"
         else
             git_root_dir=$(git rev-parse --git-common-dir)
-            
-            # Information of the worktree we are in
-            worktree_info=$(git worktree list | grep "$PWD " | xargs)
-
-            # DOES NOT SUPPORT SPACES IN NAME OF BRANCHES/WORKTREES/DIRECTORIES.
-            worktree_abs_path=$(echo "${worktree_info}" | cut -d" " -f1)
-
-            # Path to the workspace relative to the repository's root directory
+            worktree_abs_path=$(git rev-parse --show-toplevel)
             worktree_rel_path="${worktree_abs_path##"${git_root_dir}"/}"
 
             # Ignore all directories except root and worktree


### PR DESCRIPTION
The worktree selector only supported a flat worktree filesystem due to `find maxdepth -1`. Since worktrees might be nested by an unkown number or directories, `find` is not useful anymore.

This PR refactors the creation of the ignore file to parse the worktree list, supporting deep-nested worktrees.

It also refactors the code to use built-in git commands when possible.